### PR TITLE
multiprocessing bug fix

### DIFF
--- a/dr14tmeter/dr14_tmeter.py
+++ b/dr14tmeter/dr14_tmeter.py
@@ -27,8 +27,11 @@ from dr14tmeter.dr14_utils import *
 from dr14tmeter.out_messages import *
 from dr14tmeter.dr14_config import *
 from dr14tmeter.database_utils import *
+from multiprocessing import context, freeze_support, SimpleQueue
+from multiprocessing import get_start_method, set_start_method
 
 import os
+import multiprocessing
 import subprocess
 import sys
 import logging
@@ -186,8 +189,23 @@ def main():
         print_msg(
             "----------------------------------------------------------------------\n")
 
+    if not database_exists():
+        print_msg(" ")
+        print_msg(" News ... News ... News ... News ... News  !!! ")
+        print_msg(
+            " With the version 2.0.0 there is the possibility to store all results in a database")
+        print_msg(" If you want to enable this database execute the command:")
+        print_msg("  > %s --enable_database " % get_exe_name())
+        print_msg("")
+        print_msg(
+            " for more details visit: http://dr14tmeter.sourceforge.net/index.php/DR_Database ")
+
     return r
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
+    freeze_support()
+    if len(sys.argv) > 1:
+        set_start_method(sys.argv[1])
+    print(f"using start method: {get_start_method()}")
     main()


### PR DESCRIPTION
Hello, I maintain the [Fedora RPM (COPR)](https://copr.fedorainfracloud.org/coprs/sassam/dr14_tmeter/) binary for dr14_t.meter. After trying this repo a couple of days ago, I continued to encounter the multiprocessing error. 

After modifying the `dr14tmeter/dr14_tmeter.py` file based on the comments from [https://github.com/pyinstaller/pyinstaller/issues/7920](https://github.com/pyinstaller/pyinstaller/issues/7920) I'm no longer receiving the multiprocessing errors with Python 3.14. Also, it appears the `mutagen` module may now be required (I had to add it to the list of requirements in the SPEC file.)

Thank you for stepping in to continue maintaining this great program.